### PR TITLE
Support for overriding the storage url

### DIFF
--- a/getput
+++ b/getput
@@ -200,6 +200,7 @@ def parse_creds(creds_file=None):
                         'OS_USER_DOMAIN_NAME', 'OS_USER_DOMAIN_ID', \
                         'OS_REGION_NAME', 'OS_SERVICE_TYPE', 'OS_AUTH_VERSION', \
                         'OS_ENDPOINT_TYPE', 'OS_IDENTITY_API_VERSION', \
+                        'OS_STORAGE_URL', \
                         'SWIFTCLIENT_INSECURE', 'OS_CACERT', 'OS_CERT']:
         osvars[varname] = getenv(varname)
         if osvars[varname] != '':
@@ -649,6 +650,9 @@ def connect(authurl, username, password, osvars, \
     cacert = None
     if 'OS_CACERT' in osvars:
         cacert = osvars['OS_CACERT']
+
+    if 'OS_STORAGE_URL' in osvars:
+        osvars['object_storage_url'] = osvars['OS_STORAGE_URL']
 
     if 'SWIFTCLIENT_INSECURE' in osvars:
         insecure = osvars['SWIFTCLIENT_INSECURE']


### PR DESCRIPTION
Here's another `OS_` variable that was missing for some reason in #2. `OS_STORAGE_URL` allows to point the swiftclient to a different proxy URL than the one retrieved in the catalog. I'm using this right now to work with a test cluster in a region where the Keystone catalog points to the productive cluster.