### PR TITLE
Fix missing parenthesis

### DIFF
--- a/getput.1
+++ b/getput.1
@@ -209,7 +209,7 @@ start of the object as comma separated pairs, noting the first byte is byte 0.
 When there are multiple puts/gets, the same get-by-range will apply to each object.
 
 There is an interesting behavior with ranged GETs and that is when benchmarking
-using many processes with which you wish to push swift to its max. IYou can 
+using many processes with which you wish to push swift to its max. You can 
 easily find yourself in a situation where you can run many more processes for
 GETs than PUTs since the object being retrieved may be much smaller and therefore
 able to sustain higher levels of parallelism. Say you created a bunch of 100MB

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,4 @@ setup(name='gptools',
                   ('/etc/gpsuite.d', ['gpsuite.conf']),
                   ('/usr/share/doc/gptools',['getting-started.txt','RELEASE-gptools','Introduction.pdf']),
                   ('/usr/share/man/man1',['getput.1', 'gpmulti.1', 'gpsuite.1', 'gpsum.1', 'gpwhere.1'])]
-     
+      )


### PR DESCRIPTION
Pull request mirroring Issue #9 

There is a missing parenthesis in setup.py. This prevents a successful install.